### PR TITLE
Use lib64 for s390x arch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class post_install(install_data):
             os.system('glib-compile-schemas %s/share/glib-2.0/schemas' % self.install_dir)
 
 # determine lib path depending on architecture
-if (os.uname()[4].find('64') != -1):
+if (os.uname()[4].find('64') != -1 or os.uname()[4].find('s390x') != -1):
     lib_dir = 'lib64'
 else:
     lib_dir = 'lib'


### PR DESCRIPTION
I apply this patch in Fedora to fix the installation in the s390x arch